### PR TITLE
fix: add missing period to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
             to provide a compact, feature-rich interface for rapid component development. While X-Tag offers feature hooks for all Web Component APIs
             (Custom Elements, Shadow DOM, Templates, and HTML Imports), it only requires Custom Element support to operate.
             In the absence of native Custom Element support, X-Tag uses a set of <a target="_blank" href="https://github.com/webcomponents/webcomponentsjs">polyfills</a>
-            shared with Google's Polymer framework. You can view our package options in the <x-action event="viewchange" data-view="builds">Builds</x-action> section</p>
+            shared with Google's Polymer framework. You can view our package options in the <x-action event="viewchange" data-view="builds">Builds</x-action> section.</p>
 
         <div>
 


### PR DESCRIPTION
Adds a missing period to the home page. I'm not sure this is the latest source for https://x-tag.github.io? See also https://github.com/x-tag/core-2/pull/7.